### PR TITLE
fix: guard null stacks in NEI recipe expansion filter

### DIFF
--- a/src/main/java/com/github/sladki/gtnhrates/mixins/extras/NEIRecipeExpansionFilter.java
+++ b/src/main/java/com/github/sladki/gtnhrates/mixins/extras/NEIRecipeExpansionFilter.java
@@ -30,6 +30,8 @@ public class NEIRecipeExpansionFilter {
     }
 
     public Optional<String> decisiveRule(ItemStack itemStack) {
+        if (itemStack == null) return Optional.empty();
+
         String pattern;
         pattern = itemStackNEIName(itemStack).toLowerCase(Locale.ROOT);
         if (inclusionOverrides.contains(pattern)) return Optional.of("!" + pattern);
@@ -49,6 +51,8 @@ public class NEIRecipeExpansionFilter {
     }
 
     public void toggleRestriction(ItemStack itemStack) {
+        if (itemStack == null) return;
+
         Optional<String> rule = decisiveRule(itemStack);
         if (!rule.isPresent()) {
             exclusionPatterns.add(itemStackNEIName(itemStack).toLowerCase(Locale.ROOT));


### PR DESCRIPTION
Fixes #15 

`GuiBlacklistFavoriteButton` leaves `recipeResult` null when none of the recipe's results match, then passes it to the filter anyway. That's the NPE.

Added a null check to `decisiveRule` and `toggleRestriction`. `isExcluded` goes through `decisiveRule`.

Tested on 2.9.0-beta-1, GT-Not-Leisure's Shimmer recipes crashed every time before, fine now with the filter on.